### PR TITLE
Add descriptive alt text for main image

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             <p1>Inicio mi blog porque nada es real. El mundo y el universo en que vivimos no son más que una ilusión creada por nuestras mentes. Nuestro cerebro, en realidad, es un ordenador que "piensa" en términos binarios y no en términos lingüísticos. Esto es debido al hecho de que cuando pensamos, nuestros cerebros codifican nuestras ideas y percepciones en términos binarios, esto es, en códigos de 1 y de 0. Ya no hablamos de colores, de objetos, de relaciones, de palabras, de caracteres de nuestro alfabeto, de frases, de ideas, de sentimientos, de percepciones, de emociones, de tiempo, de espacio, de tiempo, de infinito..., en términos binarios. Es decir, en términos de ordenadores.
                 No es raro que muchas personas están convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño, o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", decía el poeta de los Sueños de Calipso.
             </p1>
-            <img src="Modernidad ddd - copia (2).png" alt="">
+            <img src="Modernidad ddd - copia (2).png" alt="Ilustración digital abstracta con luces amarillas, verdes y cian sobre un fondo oscuro.">
         </article>
         <article class="post">
             <h2>Sueños y alucinaciones</h2>


### PR DESCRIPTION
## Summary
- replace the empty `alt` attribute on the introductory image with a brief Spanish description of the artwork

## Testing
- python - <<'PY' (checked img elements for non-empty alt text)
- npx pa11y index.html *(fails: npm 403 due to blocked registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cb898fbc83279e50c9638322b081