### PR TITLE
Add modern layout styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,18 +1,6 @@
-:root {
-    color-scheme: dark;
-    --background: #0f172a;
-    --background-soft: rgba(15, 23, 42, 0.75);
-    --surface: rgba(15, 23, 42, 0.65);
-    --surface-border: rgba(148, 163, 184, 0.2);
-    --text-primary: #e2e8f0;
-    --text-secondary: rgba(226, 232, 240, 0.72);
-    --accent-start: #38bdf8;
-    --accent-mid: #a855f7;
-    --accent-end: #f472b6;
-}
-
 /* ====== Variables y reset ====== */
 :root {
+  color-scheme: dark;
   --background: #0f172a;          /* slate-900 */
   --text-primary: #e2e8f0;        /* slate-200 */
   --text-secondary: #cbd5e1;      /* slate-300 */
@@ -31,5 +19,232 @@
 body {
   margin: 0;
   min-height: 100vh;
-  font-family
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--background);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  transition: background 0.6s ease;
+}
 
+/* Si querés un fondo gris claro como en tu versión original, descomentá la línea siguiente */
+/* body { background-color: grey; color: #111; } */
+
+/* Estado con contenido visible (esconde hero) */
+body.content-visible {
+  background:
+    radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 60%),
+    radial-gradient(circle at bottom, rgba(244, 114, 182, 0.1), transparent 55%),
+    var(--background);
+}
+
+/* ====== Header clásico tuyo ====== */
+header {
+  background-color: black;
+  color: skyblue;
+  text-align: center;
+  padding: 5px;
+}
+
+header h1 {
+  font-size: 50px;
+}
+
+/* ====== Hero moderno de main ====== */
+.hero {
+  position: relative;
+  min-height: 100vh;
+  padding: 4rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  background:
+    radial-gradient(circle at top, rgba(168, 85, 247, 0.35), transparent 55%),
+    radial-gradient(circle at bottom, rgba(56, 189, 248, 0.45), transparent 50%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.75));
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 10% 20%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.15), transparent 65%);
+  filter: blur(40px);
+  z-index: 0;
+}
+
+.hero-title {
+  position: relative;
+  z-index: 1;
+  border: 0;
+  border-radius: 999px;
+  padding: clamp(1.25rem, 2vw + 1rem, 2rem) clamp(2.5rem, 4vw + 1.5rem, 4.5rem);
+  font-size: clamp(1.75rem, 4vw + 1rem, 3.5rem);
+  font-weight: 600;
+  color: #f8fafc;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.65), rgba(168, 85, 247, 0.65));
+  backdrop-filter: blur(12px);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.55);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 0.4s ease, box-shadow 0.4s ease, background 0.4s ease;
+}
+
+.hero-title:hover,
+.hero-title:focus-visible {
+  transform: translateY(-6px) scale(1.02);
+  box-shadow: 0 25px 55px rgba(56, 189, 248, 0.35);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(244, 114, 182, 0.75));
+  outline: none;
+}
+
+.hero-title:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.hero-accent {
+  position: relative;
+  z-index: 1;
+  width: min(90%, 960px);
+  height: clamp(120px, 18vh, 180px);
+  border-radius: 40px;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-mid), var(--accent-end));
+  box-shadow: 0 30px 60px rgba(244, 114, 182, 0.3);
+  opacity: 0.95;
+}
+
+/* Mostrar/Ocultar contenido según estado */
+body:not(.content-visible) main,
+body:not(.content-visible) footer {
+  display: none;
+}
+body.content-visible .hero {
+  display: none;
+}
+
+/* ====== Contenido ====== */
+main {
+  width: min(940px, 92%);
+  margin: 4rem auto;
+  padding: 0 0 4rem;
+  display: flex;
+  justify-content: center;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.post {
+  padding: clamp(2rem, 3vw + 1.5rem, 3rem);
+  border-radius: 32px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(20px);
+}
+
+/* Tu h2 centrado + colores de tema */
+h2 {
+  text-align: center;
+  font-size: 29px;
+  color: var(--text-primary);
+}
+
+.post h2 {
+  margin-top: 0;
+  font-size: clamp(1.75rem, 1vw + 1.6rem, 2.25rem);
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.post p {
+  font-size: clamp(1rem, 0.4vw + 1rem, 1.25rem);
+  line-height: 1.9;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+/* ====== Imagen del artículo ====== */
+/* En tu versión original: img global 19% + margin-left:40%;
+   Para no romper otras imágenes (hero, etc.), lo limito a .post-media img */
+.post-media {
+  margin: 2.5rem auto 0;
+  max-width: 520px;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 20px 55px rgba(15, 23, 42, 0.5);
+}
+.post-media img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+/* Si querés reproducir exactamente tu “miniatura a la derecha”, podés usar: */
+/*
+.post-media img {
+  width: 19%;
+  height: auto;
+  margin-left: 40%;
+}
+*/
+
+/* ====== Tus bloques de texto con IDs/clases ====== */
+.intro,
+#intro,
+.dreams,
+#dreams {
+  font-size: 25px;
+  text-align: center;
+  /* color original: black; mejor usar el color del tema para contraste */
+  color: var(--text-secondary);
+}
+
+/* ====== Footer ====== */
+footer {
+  margin-top: auto;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.65);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.75));
+  border-top: 1px solid var(--surface-border);
+}
+
+/* ====== Responsive ====== */
+@media (max-width: 768px) {
+  .hero {
+    padding: 3rem 1.25rem 2.5rem;
+    gap: 2.5rem;
+  }
+  .hero-accent {
+    border-radius: 30px;
+    height: clamp(100px, 20vw + 60px, 140px);
+  }
+  main {
+    margin: 3rem auto;
+  }
+  .post {
+    padding: clamp(1.75rem, 2vw + 1.5rem, 2.5rem);
+  }
+}
+
+/* ====== Accesibilidad: reduce motion ====== */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- incorporate the provided modern theme variables and base typography updates into `style.css`
- add hero, content, media, footer, and responsive styling blocks from the supplied CSS snippet

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca1b55dc888327b9d09877caaa5100