### PR TITLE
Add js-enabled body class for conditional content hiding

### DIFF
--- a/hola.js
+++ b/hola.js
@@ -3,6 +3,8 @@
 console.log(1 + 2);
 
 document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('js-enabled');
+
     const heroTrigger = document.querySelector('.hero-title');
     const mainContent = document.getElementById('contenido');
 

--- a/style.css
+++ b/style.css
@@ -119,8 +119,8 @@ header h1 {
 }
 
 /* Mostrar/Ocultar contenido según estado */
-body:not(.content-visible) main,
-body:not(.content-visible) footer {
+body.js-enabled:not(.content-visible) main,
+body.js-enabled:not(.content-visible) footer {
   display: none;
 }
 body.content-visible .hero {


### PR DESCRIPTION
## Summary
- add a `js-enabled` class to the `<body>` as soon as `DOMContentLoaded` fires
- scope the rules that hide `<main>` and `<footer>` to only apply when the body has `js-enabled`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca1f3ad1a0832791c28cb9afbd8c94