### PR TITLE
Remove redundant closing tags after main

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,6 @@
   </section>
 </main>
 
-            </article>
-        </section>
-    </main>
     <footer>
         <p>&copy; Copyright 2020</p>
     </footer>


### PR DESCRIPTION
## Summary
- remove duplicated closing article, section, and main tags that followed `</main>`
- ensure only the footer and script remain after the main content block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca1efca5f8832794ea1d201faf4864