### PR TITLE
Adjust article image size and add hover zoom effect

### DIFF
--- a/hola.js
+++ b/hola.js
@@ -5,20 +5,102 @@ console.log(1 + 2);
 document.addEventListener('DOMContentLoaded', () => {
     const heroTrigger = document.querySelector('.hero-title');
     const mainContent = document.getElementById('contenido');
+    const postImage = document.querySelector('.post-media img');
 
-    if (!heroTrigger) {
+    if (heroTrigger) {
+        heroTrigger.addEventListener('click', () => {
+            document.body.classList.add('content-visible');
+
+            if (!mainContent) {
+                return;
+            }
+
+            window.requestAnimationFrame(() => {
+                mainContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+        });
+    }
+
+    if (!postImage) {
         return;
     }
 
-    heroTrigger.addEventListener('click', () => {
-        document.body.classList.add('content-visible');
+    let isZooming = false;
+    let zoomAnimationFrame = null;
+    const MIN_SCALE = 1;
+    const MAX_SCALE = 1.8;
+    const ZOOM_INCREMENT = 0.018;
+    let currentScale = MIN_SCALE;
 
-        if (!mainContent) {
+    const stepZoom = () => {
+        if (!isZooming) {
+            zoomAnimationFrame = null;
             return;
         }
 
-        window.requestAnimationFrame(() => {
-            mainContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        });
+        currentScale = Math.min(MAX_SCALE, currentScale + ZOOM_INCREMENT);
+        postImage.style.transform = `scale(${currentScale})`;
+
+        if (isZooming && currentScale < MAX_SCALE) {
+            zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
+        } else {
+            zoomAnimationFrame = null;
+        }
+    };
+
+    const startZoom = () => {
+        if (isZooming) {
+            return;
+        }
+
+        isZooming = true;
+        currentScale = MIN_SCALE;
+        postImage.style.cursor = 'zoom-out';
+        postImage.style.transition = 'none';
+        postImage.style.transform = `scale(${currentScale})`;
+        zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
+    };
+
+    const stopZoom = () => {
+        if (!isZooming && currentScale === MIN_SCALE) {
+            return;
+        }
+
+        isZooming = false;
+
+        if (zoomAnimationFrame !== null) {
+            window.cancelAnimationFrame(zoomAnimationFrame);
+            zoomAnimationFrame = null;
+        }
+
+        currentScale = MIN_SCALE;
+        postImage.style.transition = '';
+        postImage.style.transform = `scale(${MIN_SCALE})`;
+        postImage.style.cursor = 'zoom-in';
+    };
+
+    const handlePointerDown = (event) => {
+        if (event.button !== undefined && event.button !== 0) {
+            return;
+        }
+
+        startZoom();
+    };
+
+    const preventDrag = (event) => {
+        event.preventDefault();
+    };
+
+    postImage.addEventListener('pointerenter', startZoom);
+    postImage.addEventListener('pointerdown', handlePointerDown);
+    postImage.addEventListener('pointerup', stopZoom);
+    postImage.addEventListener('pointerleave', stopZoom);
+    postImage.addEventListener('pointercancel', stopZoom);
+    postImage.addEventListener('dragstart', preventDrag);
+
+    postImage.addEventListener('transitionend', (event) => {
+        if (event.propertyName === 'transform' && !isZooming) {
+            postImage.style.transition = '';
+        }
     });
 });

--- a/style.css
+++ b/style.css
@@ -178,7 +178,8 @@ h2 {
    Para no romper otras imágenes (hero, etc.), lo limito a .post-media img */
 .post-media {
   margin: 2.5rem auto 0;
-  max-width: 520px;
+  width: 100%;
+  max-width: 360px;
   border-radius: 24px;
   overflow: hidden;
   box-shadow: 0 20px 55px rgba(15, 23, 42, 0.5);
@@ -187,6 +188,10 @@ h2 {
   width: 100%;
   height: auto;
   display: block;
+  transform: scale(1);
+  transition: transform 0.3s ease-out;
+  cursor: zoom-in;
+  will-change: transform;
 }
 /* Si querés reproducir exactamente tu “miniatura a la derecha”, podés usar: */
 /*


### PR DESCRIPTION
## Summary
- limit the article illustration to a smaller, centered width and prepare it for animation
- implement a pointer-driven zoom interaction that runs on hover/press and resets on release

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca1f240cac8327b4e51e9144ab3611