### PR TITLE
Add second page navigation for mundo irreal content

### DIFF
--- a/hola.js
+++ b/hola.js
@@ -3,23 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     document.body.classList.add('js-enabled');
 
-    const heroTrigger = document.querySelector('.hero-title');
-    const mainContent = document.getElementById('contenido');
     const postImage = document.querySelector('.post-media img');
-
-    if (heroTrigger) {
-        heroTrigger.addEventListener('click', () => {
-            document.body.classList.add('content-visible');
-
-            if (!mainContent) {
-                return;
-            }
-
-            window.requestAnimationFrame(() => {
-                mainContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            });
-        });
-    }
 
     if (!postImage) {
         return;

--- a/index.html
+++ b/index.html
@@ -11,37 +11,13 @@
 </head>
 <body>
 <header>
-  <h1 id="titulo">Bienvenidos a mundo donde nada es real</h1>
+  <h1 id="titulo">Bienvenidos a un mundo donde nada es real</h1>
 </header>
 
 <section class="hero">
-  <button type="button" class="hero-title">Bienvenidos a mundo donde nada es real</button>
+  <a class="hero-title" href="mundo.html">Bienvenidos a un mundo donde nada es real</a>
   <div class="hero-accent" aria-hidden="true"></div>
 </section>
-
-<main id="contenido">
-  <section class="content">
-    <article class="post">
-      <h2>Introducción</h2>
-      <p id="intro" class="intro">Inicio mi blog porque nada es real. El mundo y el universo en que vivimos no son más que una ilusión creada por nuestras mentes.</p>
-      <p>Nuestro cerebro, en realidad, es un ordenador que "piensa" en términos binarios y no en términos lingüísticos. Esto se debe a que cuando pensamos, nuestros cerebros codifican nuestras ideas y percepciones en códigos de 1 y 0, en lugar de colores, objetos, relaciones, palabras, caracteres de nuestro alfabeto, frases, ideas, sentimientos, percepciones, emociones, tiempo, espacio o infinito.</p>
-      <p>Es decir, todo se traduce en términos de ordenadores. No es raro que muchas personas estén convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", afirmaba el poeta de los Sueños de Calipso.</p>
-      <figure class="post-media">
-        <img src="Modernidad ddd - copia (2).png" alt="Representación surrealista de la modernidad">
-      </figure>
-    </article>
-
-    <article class="post">
-      <h2>Sueños y alucinaciones</h2>
-      <p id="dreams" class="dreams">No es que no exista, pero nada es real. No es que este mundo esté compuesto por percepciones, emociones, pensamientos, sentimientos, palabras, caracteres, alfabetos, conceptos, ideas, frases, objetos, relaciones, colores, líneas, superficies, extensiones, espacios, tiempos o infinitos que no existen, sino que nada es real.</p>
-      <p>El mundo es una alucinación. Todo es una ilusión. El mundo está compuesto por "creencias" y "creencias de creencias" (la clave de todo esto está en la construcción de la mente, más que en la mente en sí misma). Todo es un sueño. Todo es una alucinación. El mundo es una ilusión. El universo es una ilusión. La Tierra es una ilusión. La Naturaleza es una ilusión. La Historia es una ilusión. La Civilización es una ilusión. La Vida es una ilusión. Todo es un sueño. Todo es una alucinación.</p>
-    </article>
-  </section>
-</main>
-
-    <footer>
-        <p>&copy; Copyright 2020</p>
-    </footer>
 
     <script src="hola.js"></script>
 </body>

--- a/mundo.html
+++ b/mundo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mundo Irreal - Contenido</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="content-visible">
+<header>
+  <h1 id="titulo">Bienvenidos a un mundo donde nada es real</h1>
+</header>
+
+<nav class="page-nav" aria-label="Navegación secundaria">
+  <a class="back-button" href="index.html">← Volver al inicio</a>
+</nav>
+
+<main id="contenido">
+  <section class="content">
+    <article class="post">
+      <h2>Introducción</h2>
+      <p id="intro" class="intro">Inicio mi blog porque nada es real. El mundo y el universo en que vivimos no son más que una ilusión creada por nuestras mentes.</p>
+      <p>Nuestro cerebro, en realidad, es un ordenador que "piensa" en términos binarios y no en términos lingüísticos. Esto se debe a que cuando pensamos, nuestros cerebros codifican nuestras ideas y percepciones en códigos de 1 y 0, en lugar de colores, objetos, relaciones, palabras, caracteres de nuestro alfabeto, frases, ideas, sentimientos, percepciones, emociones, tiempo, espacio o infinito.</p>
+      <p>Es decir, todo se traduce en términos de ordenadores. No es raro que muchas personas estén convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", afirmaba el poeta de los Sueños de Calipso.</p>
+      <figure class="post-media">
+        <img src="Modernidad ddd - copia (2).png" alt="Representación surrealista de la modernidad">
+      </figure>
+    </article>
+
+    <article class="post">
+      <h2>Sueños y alucinaciones</h2>
+      <p id="dreams" class="dreams">No es que no exista, pero nada es real. No es que este mundo esté compuesto por percepciones, emociones, pensamientos, sentimientos, palabras, caracteres, alfabetos, conceptos, ideas, frases, objetos, relaciones, colores, líneas, superficies, extensiones, espacios, tiempos o infinitos que no existen, sino que nada es real.</p>
+      <p>El mundo es una alucinación. Todo es una ilusión. El mundo está compuesto por "creencias" y "creencias de creencias" (la clave de todo esto está en la construcción de la mente, más que en la mente en sí misma). Todo es un sueño. Todo es una alucinación. El mundo es una ilusión. El universo es una ilusión. La Tierra es una ilusión. La Naturaleza es una ilusión. La Historia es una ilusión. La Civilización es una ilusión. La Vida es una ilusión. Todo es un sueño. Todo es una alucinación.</p>
+    </article>
+  </section>
+</main>
+
+    <footer>
+        <p>&copy; Copyright 2020</p>
+    </footer>
+
+    <script src="hola.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -80,6 +80,9 @@ header h1 {
 .hero-title {
   position: relative;
   z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 0;
   border-radius: 999px;
   padding: clamp(1.25rem, 2vw + 1rem, 2rem) clamp(2.5rem, 4vw + 1.5rem, 4.5rem);
@@ -93,6 +96,7 @@ header h1 {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   transition: transform 0.4s ease, box-shadow 0.4s ease, background 0.4s ease;
+  text-decoration: none;
 }
 
 .hero-title:hover,
@@ -105,6 +109,42 @@ header h1 {
 
 .hero-title:active {
   transform: translateY(0) scale(0.99);
+}
+
+.page-nav {
+  width: min(940px, 92%);
+  margin: 2rem auto 1.5rem;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(168, 85, 247, 0.4));
+  color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.back-button:hover,
+.back-button:focus-visible {
+  transform: translateY(-4px);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.6), rgba(244, 114, 182, 0.5));
+  box-shadow: 0 22px 48px rgba(56, 189, 248, 0.25);
+  outline: 3px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 4px;
+}
+
+.back-button:active {
+  transform: translateY(0) scale(0.98);
 }
 
 .hero-accent {


### PR DESCRIPTION
## Summary
- convert the landing hero button into a link that opens a dedicated content page
- add `mundo.html` with the existing articles plus a styled back link to return to the start
- simplify the hero JavaScript and extend styles to support the new navigation elements

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca29c7f3b48327bb2e6f691989183e