### PR TITLE
Simplify article carousel to cycle one image at a time

### DIFF
--- a/hola.js
+++ b/hola.js
@@ -1,34 +1,139 @@
 'use strict';
 
-document.addEventListener('DOMContentLoaded', () => {
-    document.body.classList.add('js-enabled');
+const MIN_SCALE = 1;
+const MAX_SCALE = 1.8;
+const ZOOM_INCREMENT = 0.018;
+const ROTATION_INTERVAL = 5000;
 
-    const postImage = document.querySelector('.post-media img');
+const sanitizeSlide = (rawSlide) => {
+    if (!rawSlide || typeof rawSlide !== 'object') {
+        return null;
+    }
 
-    if (!postImage) {
+    const src = typeof rawSlide.src === 'string' ? rawSlide.src.trim() : '';
+
+    if (!src) {
+        return null;
+    }
+
+    const alt = typeof rawSlide.alt === 'string' ? rawSlide.alt : '';
+    const description = typeof rawSlide.description === 'string' ? rawSlide.description : '';
+
+    return { src, alt, description };
+};
+
+const parseSlidesFromData = (dataScript) => {
+    if (!dataScript || !dataScript.textContent) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(dataScript.textContent);
+
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+
+        return parsed.map(sanitizeSlide).filter(Boolean);
+    } catch (error) {
+        return [];
+    }
+};
+
+const collectSlides = (mediaContainer, imageElement, captionElement) => {
+    const dataScript = mediaContainer.querySelector('.post-media-data');
+    const slidesFromData = parseSlidesFromData(dataScript);
+
+    const fallbackSlide = sanitizeSlide({
+        src: imageElement.getAttribute('src') || '',
+        alt: imageElement.getAttribute('alt') || '',
+        description:
+            imageElement.dataset.description ||
+            (captionElement ? captionElement.textContent.trim() : ''),
+    });
+
+    if (slidesFromData.length > 0) {
+        return { slides: slidesFromData, fallbackSlide };
+    }
+
+    const slides = fallbackSlide ? [fallbackSlide] : [];
+    return { slides, fallbackSlide };
+};
+
+const initializeMediaRotation = (mediaContainer) => {
+    const imageElement = mediaContainer.querySelector('.post-media-image');
+
+    if (!imageElement) {
         return;
     }
 
+    const captionElement = mediaContainer.querySelector('.post-media-caption');
+
+    const { slides, fallbackSlide } = collectSlides(mediaContainer, imageElement, captionElement);
+
+    if (slides.length === 0) {
+        return;
+    }
+
+    const fallbackAlt =
+        (fallbackSlide && fallbackSlide.alt) || imageElement.getAttribute('alt') || '';
+    const fallbackCaption =
+        (fallbackSlide && fallbackSlide.description) ||
+        (captionElement ? captionElement.textContent.trim() : '');
+
+    let currentIndex = 0;
+    let rotationTimer = null;
     let isZooming = false;
     let zoomAnimationFrame = null;
-    const MIN_SCALE = 1;
-    const MAX_SCALE = 1.8;
-    const ZOOM_INCREMENT = 0.018;
     let currentScale = MIN_SCALE;
+
+    const stopZoomAnimation = () => {
+        if (zoomAnimationFrame !== null) {
+            window.cancelAnimationFrame(zoomAnimationFrame);
+            zoomAnimationFrame = null;
+        }
+    };
+
+    const resetZoomState = () => {
+        stopZoomAnimation();
+        isZooming = false;
+        currentScale = MIN_SCALE;
+        imageElement.style.transition = '';
+        imageElement.style.transform = `scale(${MIN_SCALE})`;
+        imageElement.style.cursor = 'zoom-in';
+    };
+
+    const applySlide = (index) => {
+        const slide = slides[index];
+
+        if (!slide) {
+            return;
+        }
+
+        imageElement.setAttribute('src', slide.src);
+        imageElement.setAttribute('alt', slide.alt || fallbackAlt);
+        imageElement.dataset.description = slide.description || '';
+
+        if (captionElement) {
+            captionElement.textContent = slide.description || fallbackCaption || '';
+        }
+
+        resetZoomState();
+    };
 
     const stepZoom = () => {
         if (!isZooming) {
-            zoomAnimationFrame = null;
+            stopZoomAnimation();
             return;
         }
 
         currentScale = Math.min(MAX_SCALE, currentScale + ZOOM_INCREMENT);
-        postImage.style.transform = `scale(${currentScale})`;
+        imageElement.style.transform = `scale(${currentScale})`;
 
         if (isZooming && currentScale < MAX_SCALE) {
             zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
         } else {
-            zoomAnimationFrame = null;
+            stopZoomAnimation();
         }
     };
 
@@ -39,28 +144,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         isZooming = true;
         currentScale = MIN_SCALE;
-        postImage.style.cursor = 'zoom-out';
-        postImage.style.transition = 'none';
-        postImage.style.transform = `scale(${currentScale})`;
+        imageElement.style.transition = 'none';
+        imageElement.style.cursor = 'zoom-out';
+        imageElement.style.transform = `scale(${currentScale})`;
         zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
-    };
-
-    const stopZoom = () => {
-        if (!isZooming && currentScale === MIN_SCALE) {
-            return;
-        }
-
-        isZooming = false;
-
-        if (zoomAnimationFrame !== null) {
-            window.cancelAnimationFrame(zoomAnimationFrame);
-            zoomAnimationFrame = null;
-        }
-
-        currentScale = MIN_SCALE;
-        postImage.style.transition = '';
-        postImage.style.transform = `scale(${MIN_SCALE})`;
-        postImage.style.cursor = 'zoom-in';
     };
 
     const handlePointerDown = (event) => {
@@ -75,16 +162,62 @@ document.addEventListener('DOMContentLoaded', () => {
         event.preventDefault();
     };
 
-    postImage.addEventListener('pointerenter', startZoom);
-    postImage.addEventListener('pointerdown', handlePointerDown);
-    postImage.addEventListener('pointerup', stopZoom);
-    postImage.addEventListener('pointerleave', stopZoom);
-    postImage.addEventListener('pointercancel', stopZoom);
-    postImage.addEventListener('dragstart', preventDrag);
+    imageElement.addEventListener('pointerenter', startZoom);
+    imageElement.addEventListener('pointerdown', handlePointerDown);
+    imageElement.addEventListener('pointerup', resetZoomState);
+    imageElement.addEventListener('pointerleave', resetZoomState);
+    imageElement.addEventListener('pointercancel', resetZoomState);
+    imageElement.addEventListener('dragstart', preventDrag);
 
-    postImage.addEventListener('transitionend', (event) => {
-        if (event.propertyName === 'transform' && !isZooming) {
-            postImage.style.transition = '';
+    const showSlide = (index) => {
+        if (index === currentIndex || !slides[index]) {
+            return;
+        }
+
+        currentIndex = index;
+        applySlide(currentIndex);
+    };
+
+    const goToNextSlide = () => {
+        const nextIndex = (currentIndex + 1) % slides.length;
+        showSlide(nextIndex);
+    };
+
+    const stopRotation = () => {
+        if (rotationTimer !== null) {
+            window.clearInterval(rotationTimer);
+            rotationTimer = null;
+        }
+    };
+
+    const startRotation = () => {
+        if (slides.length < 2) {
+            return;
+        }
+
+        stopRotation();
+        rotationTimer = window.setInterval(goToNextSlide, ROTATION_INTERVAL);
+    };
+
+    applySlide(currentIndex);
+    startRotation();
+
+    mediaContainer.addEventListener('pointerenter', stopRotation);
+    mediaContainer.addEventListener('pointerleave', startRotation);
+    mediaContainer.addEventListener('pointercancel', startRotation);
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            stopRotation();
+        } else {
+            startRotation();
         }
     });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('js-enabled');
+
+    const mediaContainers = Array.from(document.querySelectorAll('.post-media'));
+    mediaContainers.forEach(initializeMediaRotation);
 });

--- a/index.html
+++ b/index.html
@@ -27,7 +27,26 @@
       <p>Nuestro cerebro, en realidad, es un ordenador que "piensa" en términos binarios y no en términos lingüísticos. Esto se debe a que cuando pensamos, nuestros cerebros codifican nuestras ideas y percepciones en códigos de 1 y 0, en lugar de colores, objetos, relaciones, palabras, caracteres de nuestro alfabeto, frases, ideas, sentimientos, percepciones, emociones, tiempo, espacio o infinito.</p>
       <p>Es decir, todo se traduce en términos de ordenadores. No es raro que muchas personas estén convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", afirmaba el poeta de los Sueños de Calipso.</p>
       <figure class="post-media">
-        <img src="tokyo-night.png" alt="Representación surrealista de la modernidad">
+        <img
+          class="post-media-image"
+          src="tokyo-night.png.png"
+          alt="Representación surrealista de la modernidad"
+        >
+        <figcaption class="post-media-caption" aria-live="polite">modernidad y misterio</figcaption>
+        <script type="application/json" class="post-media-data">
+          [
+            {
+              "src": "tokyo-night.png.png",
+              "alt": "Representación surrealista de la modernidad",
+              "description": "modernidad y misterio"
+            },
+            {
+              "src": "cars.png.png",
+              "alt": "Nebulosa de autos que simboliza un universo en expansión",
+              "description": "universo en crecimiento"
+            }
+          ]
+        </script>
       </figure>
     </article>
 

--- a/mundo.html
+++ b/mundo.html
@@ -26,9 +26,26 @@
       <p>Nuestro cerebro, en realidad, es un ordenador que "piensa" en términos binarios y no en términos lingüísticos. Esto se debe a que cuando pensamos, nuestros cerebros codifican nuestras ideas y percepciones en códigos de 1 y 0, en lugar de colores, objetos, relaciones, palabras, caracteres de nuestro alfabeto, frases, ideas, sentimientos, percepciones, emociones, tiempo, espacio o infinito.</p>
       <p>Es decir, todo se traduce en términos de ordenadores. No es raro que muchas personas estén convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", afirmaba el poeta de los Sueños de Calipso.</p>
       <figure class="post-media">
-        <img src="tokyo-night.png.png" alt="Representación surrealista de la modernidad">
-        <img src="cars.png.png" alt="Representación surrealista de la modernidad">
-
+        <img
+          class="post-media-image"
+          src="tokyo-night.png.png"
+          alt="Representación surrealista de la modernidad"
+        >
+        <figcaption class="post-media-caption" aria-live="polite">modernidad y misterio</figcaption>
+        <script type="application/json" class="post-media-data">
+          [
+            {
+              "src": "tokyo-night.png.png",
+              "alt": "Representación surrealista de la modernidad",
+              "description": "modernidad y misterio"
+            },
+            {
+              "src": "cars.png.png",
+              "alt": "Nebulosa de autos que simboliza un universo en expansión",
+              "description": "universo en crecimiento"
+            }
+          ]
+        </script>
       </figure>
     </article>
 

--- a/style.css
+++ b/style.css
@@ -215,7 +215,7 @@ h2 {
 
 /* ====== Imagen del artículo ====== */
 /* En tu versión original: img global 19% + margin-left:40%;
-   Para no romper otras imágenes (hero, etc.), lo limito a .post-media img */
+   Para no romper otras imágenes (hero, etc.), lo limito a .post-media-image */
 .post-media {
   margin: 2.5rem auto 0;
   width: 100%;
@@ -223,8 +223,14 @@ h2 {
   border-radius: 24px;
   overflow: hidden;
   box-shadow: 0 20px 55px rgba(15, 23, 42, 0.5);
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--surface-border);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
 }
-.post-media img {
+
+.post-media-image {
   width: 100%;
   height: auto;
   display: block;
@@ -233,9 +239,20 @@ h2 {
   cursor: zoom-in;
   will-change: transform;
 }
+
+.post-media-caption {
+  margin: 0;
+  padding: 0.85rem 1.25rem 1.1rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: center;
+  color: var(--text-secondary);
+  background: rgba(15, 23, 42, 0.85);
+  border-top: 1px solid var(--surface-border);
+}
 /* Si querés reproducir exactamente tu “miniatura a la derecha”, podés usar: */
 /*
-.post-media img {
+.post-media-image {
   width: 19%;
   height: auto;
   margin-left: 40%;


### PR DESCRIPTION
## Summary
- restructure the article figures so only one image element is rendered and provide slide data via inline JSON
- tweak the post media styles to keep the active image visible while preserving the zoom cursor styling
- rewrite the rotation script to read the slide data, swap the single image with captions, and maintain the zoom interaction for each slide

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca326d485c83278e6ad959d40a246a