### PR TITLE
Implement rotating post image slideshow

### DIFF
--- a/hola.js
+++ b/hola.js
@@ -5,376 +5,175 @@ const MAX_SCALE = 1.8;
 const ZOOM_INCREMENT = 0.018;
 const ROTATION_INTERVAL = 5000;
 
-const sanitizeSlide = (rawSlide) => {
-    if (!rawSlide || typeof rawSlide !== 'object') {
-        return null;
+const createZoomController = (image) => {
+  let animationFrame = null;
+  let isZooming = false;
+  let currentScale = MIN_SCALE;
+
+  const cancelAnimation = () => {
+    if (animationFrame !== null) {
+      window.cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+    }
+  };
+
+  const reset = () => {
+    cancelAnimation();
+    isZooming = false;
+    currentScale = MIN_SCALE;
+    image.style.transform = `scale(${MIN_SCALE})`;
+    image.style.cursor = 'zoom-in';
+  };
+
+  const stepZoom = () => {
+    if (!isZooming) {
+      animationFrame = null;
+      return;
     }
 
-    const src = typeof rawSlide.src === 'string' ? rawSlide.src.trim() : '';
+    currentScale = Math.min(MAX_SCALE, currentScale + ZOOM_INCREMENT);
+    image.style.transform = `scale(${currentScale})`;
 
-    if (!src) {
-        return null;
+    if (currentScale >= MAX_SCALE) {
+      isZooming = false;
+      animationFrame = null;
+      return;
     }
 
-    const alt = typeof rawSlide.alt === 'string' ? rawSlide.alt : '';
-    const description = typeof rawSlide.description === 'string' ? rawSlide.description : '';
+    animationFrame = window.requestAnimationFrame(stepZoom);
+  };
 
-    return { src, alt, description };
-};
-
-const parseSlidesFromData = (dataScript) => {
-    if (!dataScript || !dataScript.textContent) {
-        return [];
+  const startZoom = () => {
+    if (isZooming) {
+      return;
     }
 
- codex/implement-image-slideshow-with-captions-cbh1i9
-    try {
-        const parsed = JSON.parse(dataScript.textContent);
+    isZooming = true;
+    image.style.cursor = 'zoom-out';
+    animationFrame = window.requestAnimationFrame(stepZoom);
+  };
 
-        if (!Array.isArray(parsed)) {
-            return [];
-        }
-
-        return parsed.map(sanitizeSlide).filter(Boolean);
-    } catch (error) {
-        return [];
-    }
-};
-
-const collectSlides = (mediaContainer, imageElement, captionElement) => {
-    const dataScript = mediaContainer.querySelector('.post-media-data');
-    const slidesFromData = parseSlidesFromData(dataScript);
-
-    const fallbackSlide = sanitizeSlide({
-        src: imageElement.getAttribute('src') || '',
-        alt: imageElement.getAttribute('alt') || '',
-        description:
-            imageElement.dataset.description ||
-            (captionElement ? captionElement.textContent.trim() : ''),
-    });
-
-    if (slidesFromData.length > 0) {
-        return { slides: slidesFromData, fallbackSlide };
+  const handlePointerDown = (event) => {
+    if (event.button !== undefined && event.button !== 0) {
+      return;
     }
 
-    const slides = fallbackSlide ? [fallbackSlide] : [];
-    return { slides, fallbackSlide };
+    startZoom();
+  };
+
+  const preventDrag = (event) => {
+    event.preventDefault();
+  };
+
+  image.addEventListener('pointerenter', startZoom);
+  image.addEventListener('pointerdown', handlePointerDown);
+  image.addEventListener('pointerup', reset);
+  image.addEventListener('pointerleave', reset);
+  image.addEventListener('pointercancel', reset);
+  image.addEventListener('dragstart', preventDrag);
+
+  reset();
+
+  return { reset };
 };
 
 const initializeMediaRotation = (mediaContainer) => {
-    const imageElement = mediaContainer.querySelector('.post-media-image');
+  const images = Array.from(mediaContainer.querySelectorAll('.post-media-image'));
+  const caption = mediaContainer.querySelector('.post-media-caption');
 
-    if (!imageElement) {
-        return;
+  if (images.length === 0) {
+    return;
+  }
+
+  let currentIndex = images.findIndex((image) => image.classList.contains('is-active'));
+  if (currentIndex < 0) {
+    currentIndex = 0;
+  }
+
+  images.forEach((image, index) => {
+    if (index === currentIndex) {
+      image.classList.add('is-active');
+    } else {
+      image.classList.remove('is-active');
+    }
+  });
+
+  const controllers = images.map((image) => createZoomController(image));
+
+  const updateCaption = () => {
+    if (!caption) {
+      return;
     }
 
-    const captionElement = mediaContainer.querySelector('.post-media-caption');
+    const activeImage = images[currentIndex];
+    const description = activeImage.dataset.description || '';
+    caption.textContent = description;
+  };
 
-    const { slides, fallbackSlide } = collectSlides(mediaContainer, imageElement, captionElement);
+  controllers.forEach((controller) => {
+    controller.reset();
+  });
 
-    if (slides.length === 0) {
-        return;
+  updateCaption();
+
+  const showImage = (nextIndex) => {
+    if (nextIndex === currentIndex || !images[nextIndex]) {
+      return;
     }
 
-    const fallbackAlt =
-        (fallbackSlide && fallbackSlide.alt) || imageElement.getAttribute('alt') || '';
-    const fallbackCaption =
-        (fallbackSlide && fallbackSlide.description) ||
-        (captionElement ? captionElement.textContent.trim() : '');
+    controllers[currentIndex].reset();
+    images[currentIndex].classList.remove('is-active');
 
-    let currentIndex = 0;
-    let rotationTimer = null;
-    let isZooming = false;
-    let zoomAnimationFrame = null;
-    let currentScale = MIN_SCALE;
+    currentIndex = nextIndex;
 
-    const stopZoomAnimation = () => {
-        if (zoomAnimationFrame !== null) {
-            window.cancelAnimationFrame(zoomAnimationFrame);
-            zoomAnimationFrame = null;
-        }
-    };
-
-    const resetZoomState = () => {
-        stopZoomAnimation();
-        isZooming = false;
-        currentScale = MIN_SCALE;
-        imageElement.style.transition = '';
-        imageElement.style.transform = `scale(${MIN_SCALE})`;
-        imageElement.style.cursor = 'zoom-in';
-    };
-
-    const applySlide = (index) => {
-        const slide = slides[index];
-
-        if (!slide) {
-            return;
-        }
-
-        imageElement.setAttribute('src', slide.src);
-        imageElement.setAttribute('alt', slide.alt || fallbackAlt);
-        imageElement.dataset.description = slide.description || '';
-
-        if (captionElement) {
-            captionElement.textContent = slide.description || fallbackCaption || '';
-        }
-
-        resetZoomState();
-    };
-
-    const stepZoom = () => {
-        if (!isZooming) {
-            stopZoomAnimation();
-            return;
-        }
-
-        currentScale = Math.min(MAX_SCALE, currentScale + ZOOM_INCREMENT);
-        imageElement.style.transform = `scale(${currentScale})`;
-=======
-    const mediaContainer = document.querySelector('.post-media');
-
-    if (!mediaContainer) {
-        return;
-    }
-
-    const images = Array.from(mediaContainer.querySelectorAll('.post-media-image'));
-
-    if (images.length === 0) {
-        return;
-    }
-
-    const caption = mediaContainer.querySelector('.post-media-caption');
-
-    const MIN_SCALE = 1;
-    const MAX_SCALE = 1.8;
-    const ZOOM_INCREMENT = 0.018;
-    const ROTATION_INTERVAL = 5000;
-
-    const controllers = images.map((image) => {
-        let isZooming = false;
-        let zoomAnimationFrame = null;
-        let currentScale = MIN_SCALE;
-
-        const stepZoom = () => {
-            if (!isZooming) {
-                zoomAnimationFrame = null;
-                return;
-            }
-
-            currentScale = Math.min(MAX_SCALE, currentScale + ZOOM_INCREMENT);
-            image.style.transform = `scale(${currentScale})`;
-
-            if (isZooming && currentScale < MAX_SCALE) {
-                zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
-            } else {
-                zoomAnimationFrame = null;
-            }
-        };
-
-        const startZoom = () => {
-            if (isZooming || !image.classList.contains('is-active')) {
-                return;
-            }
-
-            isZooming = true;
-            currentScale = MIN_SCALE;
-            image.style.cursor = 'zoom-out';
-            image.style.transition = 'none';
-            image.style.transform = `scale(${currentScale})`;
-            zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
-        };
-
-        const finishZoom = () => {
-            if (zoomAnimationFrame !== null) {
-                window.cancelAnimationFrame(zoomAnimationFrame);
-                zoomAnimationFrame = null;
-            }
-
-            isZooming = false;
-            currentScale = MIN_SCALE;
-            image.style.transition = '';
-            image.style.transform = `scale(${MIN_SCALE})`;
-            image.style.cursor = 'zoom-in';
-        };
-
-        const handlePointerDown = (event) => {
-            if (event.button !== undefined && event.button !== 0) {
-                return;
-            }
-
-            startZoom();
-        };
-
-        const preventDrag = (event) => {
-            event.preventDefault();
-        };
-
-        image.addEventListener('pointerenter', startZoom);
-        image.addEventListener('pointerdown', handlePointerDown);
-        image.addEventListener('pointerup', finishZoom);
-        image.addEventListener('pointerleave', finishZoom);
-        image.addEventListener('pointercancel', finishZoom);
-        image.addEventListener('dragstart', preventDrag);
-        image.addEventListener('transitionend', (event) => {
-            if (event.propertyName === 'transform' && !isZooming) {
-                image.style.transition = '';
-            }
-        });
-
-        return {
-            reset: finishZoom,
-        };
-    });
-
-    let currentIndex = images.findIndex((image) => image.classList.contains('is-active'));
-
-    if (currentIndex < 0) {
-        currentIndex = 0;
-    }
- main
-
-    images.forEach((image, index) => {
-        if (index === currentIndex) {
-            image.classList.add('is-active');
-        } else {
- codex/implement-image-slideshow-with-captions-cbh1i9
-            stopZoomAnimation();
-=======
-            image.classList.remove('is-active');
- main
-        }
-    });
-
-    const updateCaption = () => {
-        if (!caption) {
-            return;
-        }
-
- codex/implement-image-slideshow-with-captions-cbh1i9
-        isZooming = true;
-        currentScale = MIN_SCALE;
-        imageElement.style.transition = 'none';
-        imageElement.style.cursor = 'zoom-out';
-        imageElement.style.transform = `scale(${currentScale})`;
-        zoomAnimationFrame = window.requestAnimationFrame(stepZoom);
-    };
-
-    const handlePointerDown = (event) => {
-        if (event.button !== undefined && event.button !== 0) {
-            return;
-        }
-
-        startZoom();
-    };
-
-    const preventDrag = (event) => {
-        event.preventDefault();
-    };
-
-    imageElement.addEventListener('pointerenter', startZoom);
-    imageElement.addEventListener('pointerdown', handlePointerDown);
-    imageElement.addEventListener('pointerup', resetZoomState);
-    imageElement.addEventListener('pointerleave', resetZoomState);
-    imageElement.addEventListener('pointercancel', resetZoomState);
-    imageElement.addEventListener('dragstart', preventDrag);
-
-    const showSlide = (index) => {
-        if (index === currentIndex || !slides[index]) {
-            return;
-        }
-
-        currentIndex = index;
-        applySlide(currentIndex);
-    };
-
-    const goToNextSlide = () => {
-        const nextIndex = (currentIndex + 1) % slides.length;
-        showSlide(nextIndex);
-    };
-
-=======
-        const activeImage = images[currentIndex];
-        const description = activeImage.dataset.description || '';
-        caption.textContent = description;
-    };
-
-    controllers.forEach((controller) => {
-        controller.reset();
-    });
-
+    images[currentIndex].classList.add('is-active');
+    controllers[currentIndex].reset();
     updateCaption();
+  };
 
-    const showImage = (nextIndex) => {
-        if (nextIndex === currentIndex) {
-            return;
-        }
+  const goToNextImage = () => {
+    const nextIndex = (currentIndex + 1) % images.length;
+    showImage(nextIndex);
+  };
 
-        controllers[currentIndex].reset();
-        images[currentIndex].classList.remove('is-active');
+  let rotationTimer = null;
 
-        currentIndex = nextIndex;
-
-        images[currentIndex].classList.add('is-active');
-        controllers[currentIndex].reset();
-        updateCaption();
-    };
-
-    const goToNextImage = () => {
-        const nextIndex = (currentIndex + 1) % images.length;
-        showImage(nextIndex);
-    };
-
-    let rotationTimer = null;
-
- main
-    const stopRotation = () => {
-        if (rotationTimer !== null) {
-            window.clearInterval(rotationTimer);
-            rotationTimer = null;
-        }
-    };
-
-    const startRotation = () => {
- codex/implement-image-slideshow-with-captions-cbh1i9
-        if (slides.length < 2) {
-=======
-        if (images.length < 2) {
- main
-            return;
-        }
-
-        stopRotation();
- codex/implement-image-slideshow-with-captions-cbh1i9
-        rotationTimer = window.setInterval(goToNextSlide, ROTATION_INTERVAL);
-    };
-
-    applySlide(currentIndex);
-    startRotation();
-=======
-        rotationTimer = window.setInterval(goToNextImage, ROTATION_INTERVAL);
-    };
-
-    if (images.length >= 2) {
-        startRotation();
+  const stopRotation = () => {
+    if (rotationTimer !== null) {
+      window.clearInterval(rotationTimer);
+      rotationTimer = null;
     }
-main
+  };
 
-    mediaContainer.addEventListener('pointerenter', stopRotation);
-    mediaContainer.addEventListener('pointerleave', startRotation);
-    mediaContainer.addEventListener('pointercancel', startRotation);
+  const startRotation = () => {
+    if (images.length < 2) {
+      return;
+    }
 
-    document.addEventListener('visibilitychange', () => {
-        if (document.hidden) {
-            stopRotation();
-        } else {
-            startRotation();
-        }
-    });
+    stopRotation();
+    rotationTimer = window.setInterval(goToNextImage, ROTATION_INTERVAL);
+  };
+
+  if (images.length >= 2) {
+    startRotation();
+  }
+
+  mediaContainer.addEventListener('pointerenter', stopRotation);
+  mediaContainer.addEventListener('pointerleave', startRotation);
+  mediaContainer.addEventListener('pointercancel', startRotation);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopRotation();
+    } else {
+      startRotation();
+    }
+  });
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-    document.body.classList.add('js-enabled');
+  document.body.classList.add('js-enabled');
 
-    const mediaContainers = Array.from(document.querySelectorAll('.post-media'));
-    mediaContainers.forEach(initializeMediaRotation);
+  const mediaContainers = Array.from(document.querySelectorAll('.post-media'));
+  mediaContainers.forEach(initializeMediaRotation);
 });

--- a/index.html
+++ b/index.html
@@ -28,27 +28,6 @@
       <p>Es decir, todo se traduce en términos de ordenadores. No es raro que muchas personas estén convencidas de que todo es una ilusión. De hecho, los filósofos griegos ya lo advirtieron. "No es un sueño, pues, lo que estás viendo, sino una visión de sueños", decía Sócrates. "¿Qué es lo que estoy viendo? ¿Un sueño o una visión de sueños?", se preguntaba Platón en su República. "Todo esto no son más que visiones de un sueño", decía Aristóteles. "Esto es un sueño", afirmaba el poeta de los Sueños de Calipso.</p>
       <figure class="post-media">
         <img
- codex/implement-image-slideshow-with-captions-cbh1i9
-          class="post-media-image"
-          src="tokyo-night.png.png"
-          alt="Representación surrealista de la modernidad"
-        >
-        <figcaption class="post-media-caption" aria-live="polite">modernidad y misterio</figcaption>
-        <script type="application/json" class="post-media-data">
-          [
-            {
-              "src": "tokyo-night.png.png",
-              "alt": "Representación surrealista de la modernidad",
-              "description": "modernidad y misterio"
-            },
-            {
-              "src": "cars.png.png",
-              "alt": "Nebulosa de autos que simboliza un universo en expansión",
-              "description": "universo en crecimiento"
-            }
-          ]
-        </script>
-=======
           class="post-media-image is-active"
           src="tokyo-night.png.png"
           alt="Representación surrealista de la modernidad"
@@ -60,8 +39,9 @@
           alt="Nebulosa de autos que simboliza un universo en expansión"
           data-description="universo en crecimiento"
         >
-        <figcaption class="post-media-caption" aria-live="polite">modernidad y misterio</figcaption>
- main
+        <figcaption class="post-media-caption" aria-live="polite">
+          modernidad y misterio
+        </figcaption>
       </figure>
     </article>
 

--- a/style.css
+++ b/style.css
@@ -239,14 +239,9 @@ h2 {
   cursor: zoom-in;
   will-change: transform;
 }
-
- codex/implement-image-slideshow-with-captions-cbh1i9
-=======
 .post-media-image.is-active {
   display: block;
 }
-
- main
 .post-media-caption {
   margin: 0;
   padding: 0.85rem 1.25rem 1.1rem;


### PR DESCRIPTION
## Summary
- clean the post figure markup to host both the Tokyo night and cars images with their captions
- add JavaScript-driven rotation that swaps the active image every five seconds while keeping the zoom effect
- simplify the related CSS so only the active slide is visible

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca396099c48327aeebf1f6691e8d0c